### PR TITLE
[FIX] view-cov for Linux

### DIFF
--- a/update/Makefile
+++ b/update/Makefile
@@ -5,6 +5,14 @@
 # Set the node.js environment to test:
 NODE_ENV ?= test
 
+# Platform
+PLATFORM ?= $(shell uname -o)
+
+ifeq ($(PLATFORM), GNU/Linux)
+	OPEN ?= xdg-open
+else
+	OPEN ?= open
+endif
 
 # NOTES #
 
@@ -98,8 +106,7 @@ test-istanbul-mocha: node_modules
 view-cov: view-istanbul-report
 
 view-istanbul-report:
-	open $(ISTANBUL_HTML_REPORT_PATH)
-
+	$(OPEN) $(ISTANBUL_HTML_REPORT_PATH)
 
 
 # LINT #


### PR DESCRIPTION
This is a very minor thing, but working on Ubuntu the command `make view-cov` will fail with the error message `Couldn't get a file descriptor referring to the console`. The problem is that  `open` does not exist; instead `xdg-open` is supported by the major Linux distributions, so one would net to detect the OS and then fire the appropriate action. 

I made a few little changes to the Makefile to fix this.
